### PR TITLE
Add spell checking to prompt text input box

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -712,6 +712,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						minRows={3}
 						maxRows={15}
 						autoFocus={true}
+						spellCheck={true}
 						style={{
 							width: "100%",
 							outline: "none",

--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
@@ -160,4 +160,12 @@ describe("ChatTextArea", () => {
 			expect(setInputValue).toHaveBeenCalledWith("Enhanced test prompt")
 		})
 	})
+
+	describe("spellCheck attribute", () => {
+		it("should have spellCheck attribute set to true", () => {
+			render(<ChatTextArea {...defaultProps} />)
+			const textArea = screen.getByPlaceholderText("Type a message...")
+			expect(textArea).toHaveAttribute("spellCheck", "true")
+		})
+	})
 })


### PR DESCRIPTION
Add spell checking to the prompt text input box.

* Enable spell checking by setting the `spellCheck` attribute to `true` on the `DynamicTextArea` component in `webview-ui/src/components/chat/ChatTextArea.tsx`.
* Add a test to verify that the spell checking attribute is set to `true` in `webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx`.

